### PR TITLE
login and register bug fixed

### DIFF
--- a/src/modules/auth/authSlice.js
+++ b/src/modules/auth/authSlice.js
@@ -43,6 +43,15 @@ export const fetchMe = createAsyncThunk(
   }
 );
 
+// Helper function to clear persist storage
+const clearPersistStorage = () => {
+  try {
+    localStorage.removeItem('persist:root');
+  } catch (error) {
+    console.error('Error clearing persist storage:', error);
+  }
+};
+
 const authSlice = createSlice({
   name: "auth",
   initialState: {
@@ -55,7 +64,10 @@ const authSlice = createSlice({
     logout: (state) => {
       state.user = null; 
       state.token = null;
-
+      clearPersistStorage();
+    },
+    clearError: (state) => {
+      state.error = null;
     },
   },
   extraReducers: (b) => {
@@ -66,7 +78,13 @@ const authSlice = createSlice({
         s.token=d?.token||null;
         s.user = d ? { username:d.username, email:d.email, id:d.userId, role: d.role } : null;
      })
-     .addCase(registerUser.rejected, (s,a)=>{s.loading=false;s.error=a.payload?.data.message||"Register failed";})
+     .addCase(registerUser.rejected, (s,a)=>{
+        s.loading=false;
+        s.error=a.payload?.data?.message||"Register failed";
+        s.user = null;
+        s.token = null;
+        clearPersistStorage();
+     })
 
      .addCase(loginUser.pending, (s)=>{s.loading=true;s.error=null;})
      .addCase(loginUser.fulfilled, (s,a)=>{
@@ -76,7 +94,13 @@ const authSlice = createSlice({
         console.log("Login successful, token:", s.token);
         s.user = d ? { username:d.username, email:d.email, id:d.userId, role: d.role } : null;
      })
-     .addCase(loginUser.rejected, (s,a)=>{s.loading=false;s.error=a.payload?.data.message||"Login failed";})
+     .addCase(loginUser.rejected, (s,a)=>{
+        s.loading=false;
+        s.error=a.payload?.data?.message||"Login failed";
+        s.user = null;
+        s.token = null;
+        clearPersistStorage();
+     })
 
      .addCase(fetchMe.pending, (s)=>{s.loading=true;s.error=null;})
      .addCase(fetchMe.fulfilled, (s,a)=>{
@@ -85,9 +109,15 @@ const authSlice = createSlice({
         console.log("fetchMe successful, user data:", d);
         if (d) s.user = { username:d.data.username, email:d.data.email, id:d.data.id, role: d.data.role };
      })
-     .addCase(fetchMe.rejected, (s,a)=>{s.loading=false;s.error=a.payload?.message;});
+     .addCase(fetchMe.rejected, (s,a)=>{
+        s.loading=false;
+        s.error=a.payload?.message;
+        s.user = null;
+        s.token = null;
+        clearPersistStorage();
+     });
   },
 });
 
-export const { logout } = authSlice.actions;
+export const { logout, clearError } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
This pull request improves the error handling and state management in the authentication slice by ensuring user and token data are cleared, and persistent storage is reset on authentication failures or logout. It also adds a new action to clear error messages in the state.

**Authentication state and persistent storage management:**

* Added a `clearPersistStorage` helper function to remove the `'persist:root'` key from `localStorage` and integrated it into logout and all authentication failure cases to ensure stale user and token data are not persisted.
* Updated the reducers for `registerUser.rejected`, `loginUser.rejected`, and `fetchMe.rejected` to clear user and token state and invoke `clearPersistStorage` on failures. [[1]](diffhunk://#diff-c1876ca0f9cfff7e29f19cba1623b5649262cc5661692554a3dd452714177274L69-R87) [[2]](diffhunk://#diff-c1876ca0f9cfff7e29f19cba1623b5649262cc5661692554a3dd452714177274L79-R103) [[3]](diffhunk://#diff-c1876ca0f9cfff7e29f19cba1623b5649262cc5661692554a3dd452714177274L88-R122)
* Updated the `logout` reducer to also clear persistent storage.

**Error handling improvements:**

* Added a new `clearError` reducer to reset error messages in the state, and exported it for use in the application. [[1]](diffhunk://#diff-c1876ca0f9cfff7e29f19cba1623b5649262cc5661692554a3dd452714177274L58-R70) [[2]](diffhunk://#diff-c1876ca0f9cfff7e29f19cba1623b5649262cc5661692554a3dd452714177274L88-R122)